### PR TITLE
fix minor typo in CWE-134 code sample

### DIFF
--- a/help/implementing/cloud-manager/custom-code-quality-rules.md
+++ b/help/implementing/cloud-manager/custom-code-quality-rules.md
@@ -92,7 +92,7 @@ Using a format string from an external source (such a request parameter or user-
 ```java
 protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response) {
   String messageFormat = request.getParameter("messageFormat");
-  request.getResource().getValueMap().put("some property", String.format(messageFormat, "some text");
+  request.getResource().getValueMap().put("some property", String.format(messageFormat, "some text"));
   response.sendStatus(HttpServletResponse.SC_OK);
 }
 ```


### PR DESCRIPTION
Same issue as https://github.com/AdobeDocs/experience-manager-cloud-manager.en/pull/20