### PR TITLE
Update content-fragments-models.md

### DIFF
--- a/help/assets/content-fragments/content-fragments-models.md
+++ b/help/assets/content-fragments/content-fragments-models.md
@@ -71,6 +71,10 @@ The content fragment model effectively defines the structure of the resulting co
      * Many properties are self-explanatory, for additional details see [Properties](#properties).
      * Typing a **Field Label** will auto-complete the **Property Name**  - if empty, and it can be manually updated afterwards.
 
+>[!CAUTION]
+>
+>When manually updating data type Property Names, note that names must contain only Latin characters, numerical digits and underscore "_" as special character.  
+     
      For example:
 
      ![field properties](assets/cfm-models-05.png)


### PR DESCRIPTION
Added cautionary note for modifying Property Names for model data types. Customers have run into the issue. 

>[!CAUTION]
>
>When manually updating data type Property Names, note that names must contain only Latin characters, numerical digits and underscore "_" as special character. If models created in earlier versions of AEM contain illegal characters, please remove or update those characters.  