### PR TITLE
Added some changes for CTT 2.0 documents 

### DIFF
--- a/help/journey-migration/content-transfer-tool/using-content-transfer-tool/getting-started-content-transfer-tool.md
+++ b/help/journey-migration/content-transfer-tool/using-content-transfer-tool/getting-started-content-transfer-tool.md
@@ -28,16 +28,8 @@ The Content Transfer Tool can be downloaded as a zip file from the Software Dist
 
 The source AEM instance may be running behind a firewall where it can only reach certain hosts which have been added to an Allow List. In order to successfully run an extraction, the following endpoints will need to be accessible from the instance that is running AEM:
 
-* The target AEM as a Cloud Service environment: `author-p<program_id>-e<env_id>.adobeaemcloud.com`
-* The Azure blob storage service: `*.blob.core.windows.net`
-* The User Mapping IO endpoint: `usermanagement.adobe.io`
-
-To test connectivity to the target AEM as a Cloud Service environment, issue the following cURL command from the shell of the source instance (replace `program_id`, `environment_id`, and `migration_token`):
-
-`curl -i https://author-p<program_id>-e<environment_id>.adobeaemcloud.com/api/migration/migrationSet -H "Authorization: Bearer <migration_token>"`
-
->[!NOTE]
->If an `HTTP/2 200` is received, a connection to AEM as a Cloud Service was successful.
+* The Azure blob storage service to run extraction (no direct connectivity to cloud author/publisher required in CTT 2.0) : `https://casstorageprod.blob.core.windows.net`
+* The User Mapping IO endpoint for running usermapping service : `usermanagement.adobe.io`
 
 ### Enable SSL Logging {#enable-ssl-logging}
 


### PR DESCRIPTION
Got these updates from Adobe support specific to CTT 2.0. 

Still don't know how to check connectivity in CTT 2.0 as there is no migration token link in 2.0 version which was present in CTT earlier version.