### PR TITLE
Splunk Forwarding requirements

### DIFF
--- a/help/implementing/developing/introduction/logging.md
+++ b/help/implementing/developing/introduction/logging.md
@@ -554,7 +554,7 @@ The properties above should be specified for each relevant program/environment t
 >
 >Splunk forwarding for sandbox program environments is not supported.
 
-You should make sure that the initial request includes all dev environment that should be enabled, in addition to the stage/prod environments.
+You should make sure that the initial request includes all dev environment that should be enabled, in addition to the stage/prod environments. Splunk must have an SSL certificate, and be public facing. 
 
 If any new dev environments created after the initial request are intended to have Splunk forwarding, but don't have it enabled, an additional request should be made.
 


### PR DESCRIPTION
Splunk environment must be public facing and have an SSL cert so that traffic can go over https. http is not supported.