### PR TITLE
Correct content package installation

### DIFF
--- a/help/implementing/deploying/overview.md
+++ b/help/implementing/deploying/overview.md
@@ -288,7 +288,7 @@ AEM as a Cloud Service on the other hand is more opinionated about which run mod
 * OSGI configuration run modes must reference RDE, dev, stage, prod for the environment or author, publish for the service. A combination of `<service>.<environment_type>` is being supported whereas these have to be used in this particular order (for example `author.dev` or `publish.prod`). The OSGI tokens should be referenced directly from code rather than using the `getRunModes` method, which will no longer include the `environment_type` at runtime. For more information, see [Configuring OSGi for AEM as a Cloud Service](/help/implementing/deploying/configuring-osgi.md).
 * OSGI bundles run modes are limited to the service (author, publish). Per-run mode OSGI bundles should be installed in the content package under either `install/author` or `install/publish`.
 
-Like the existing AEM solutions, there is no way to use run modes to install just content for specific environments or services. If it was desired to seed a dev environment with data or HTML that isn't on stage or production, package manager could be used.
+In AEM as a Cloud Service does not allow to use run modes to install content for specific environments or services. If it was desired to seed a dev environment with data or HTML that isn't on stage or production, package manager could be used.
 
 The supported runmode configurations are:
 


### PR DESCRIPTION
In AEM 6.x it is actually possible to install environment specific content packages using run modes