### PR TITLE
Add note that annotations are not written back to the PDF document

### DIFF
--- a/help/assets/manage-pdf-documents.md
+++ b/help/assets/manage-pdf-documents.md
@@ -106,6 +106,9 @@ Following are the Annotations that can be applied on a PDF document:
         </tr>
     </table>
 
+> NOTE
+> * Annotations are stored in Experience Manager Assets and not written back to the PDF document.  
+
 ## Support for Multiple Pages Preview for Documents in Other Formats {#multi-format}
 
 In addition to the PDF documents, you can also preview multiple pages for documents in other format types. The supported document format types are TXT, RTF, DOC, DOCX, PPT, PPTX, XLS, and XLSX. Experience Manager Assets automatically converts these document formats into a PDF format and make them available for preview.


### PR DESCRIPTION
This is a note to clarify that annotations are not written back to PDF documents.