### PR TITLE
Update configuring-advanced-networking.md

### DIFF
--- a/help/security/configuring-advanced-networking.md
+++ b/help/security/configuring-advanced-networking.md
@@ -1,3 +1,19 @@
+
+Comments:  in each section where it says to run a POST and PUT command can we put an example?  For instance, 
+
+curl -X PUT https://cloudmanager.adobe.io/api/program/{programId}/environment/{environmentId}/advancedNetworking \
+-H 'x-gw-ims-org-id: <ORGANIZATION_ID>' \
+-H 'x-api-key: <CLIENT_ID>' \
+-H 'Authorization: Bearer <ACCESS_TOKEN>' \
+-H 'Content-Type: application/json' \
+-d @./vpn-configure.json
+
+These details are in the VPN tutorial but it is confusing to have to bounce back and forth between the articles.
+
+https://experienceleague.adobe.com/en/docs/experience-manager-learn/cloud-service/networking/vpn
+
+In this document it lists 'POST `/program/<programId>/networkInfrastructures` but leaves out the fact that  you need to to go to 'https://cloudmanager.adobe.io/api etc..'
+
 ---
 title: Configuring Advanced Networking for AEM as a Cloud Service
 description: Learn how to configure advanced networking features like VPN or a flexible or dedicated egress IP address for AEM as a Cloud Service


### PR DESCRIPTION
It's confusing to have to bounce back and forth between this article and https://experienceleague.adobe.com/en/docs/experience-manager-learn/cloud-service/networking/vpn.

These two articles do not agree with each other.  

https://experienceleague.adobe.com/en/docs/experience-manager-learn/cloud-service/networking/vpn

states you have to use Curl to do things like port forwarding but this document correctly notes that it can all be done through the UI.

furthermore,  https://experienceleague.adobe.com/en/docs/experience-manager-learn/cloud-service/networking/vpn gives you the CURL command examples needed to use the APIs but this document doesn't.  It just says use POST and pass the payload configuration.  How to pass that that information is only in https://experienceleague.adobe.com/en/docs/experience-manager-learn/cloud-service/networking/vpn.

It is very confusing :)