### PR TITLE
docs(security/mail-oauth2): add troubleshooting reference to AEM Email Doctor community tool

### DIFF
--- a/help/security/oauth2-support-for-mail-service.md
+++ b/help/security/oauth2-support-for-mail-service.md
@@ -250,3 +250,11 @@ In the cURL token request, replace the scope with:
 ### Troubleshooting {#troubleshooting}
 
 If the mail service is not working properly, regenerate the `refreshToken`. Use [Generating the Refresh Token](#generating-the-refresh-token) when you use SMTP and OAuth2, or [Generating the Refresh Token](#graph-generating-the-refresh-token) when you use Microsoft Graph. Pass the new value via Cloud Manager API; deployment can take a few minutes.
+
+#### Community Diagnostic Tool: AEM Email Doctor {#aem-email-doctor}
+
+The open-source [AEM Email Doctor](https://github.com/rwunsch/aem-email-doctor) tool (Apache-2.0) can help diagnose OAuth2 mail configuration issues between AEM as a Cloud Service and Microsoft&reg; 365. It performs an end-to-end validation of OAuth2 token generation and the SMTP handshake against `smtp.office365.com:587`, prints the full handshake transcript, and generates the matching OSGi configurations (`com.day.cq.mailer.oauth.impl.OAuthConfigurationProviderImpl` and `com.day.cq.mailer.DefaultMailService`) along with the corresponding Cloud Manager variable commands.
+
+This lets you quickly narrow down — before opening a support escalation — whether a problem is on the **AEM side** (for example incomplete scopes, an expired refresh token, port or address mismatches in the OSGi configuration) or on the **Microsoft&reg; side** (for example tenant-wide SMTP AUTH disabled, app registration, Send-As permissions).
+
+The tool is community-maintained and is not officially supported by Adobe. For questions or feedback, reach out to the author on Slack at `wunsch@adobe.com`.


### PR DESCRIPTION
## What this changes

Adds a short subsection at the end of the **Troubleshooting** section on the *OAuth2 Support for the Mail Service* page that points readers at the community-maintained [AEM Email Doctor](https://github.com/rwunsch/aem-email-doctor) (Apache-2.0).

## Why

Over the last several months a number of AEMaaCS customers have hit OAuth2 mail-configuration issues with Microsoft® 365 — typical symptoms are `535 5.7.3 Authentication unsuccessful` or `AADSTS70008`. A recurring pattern is that it is not obvious whether the root cause lives on the AEM side or on the Microsoft® side, which leads to long escalation loops between Adobe and Microsoft.

**AEM Email Doctor** is an open-source diagnostic tool that automates this triage: it performs the OAuth2 token exchange and a full SMTP handshake against `smtp.office365.com:587` and prints the complete transcript. That makes it fast to decide whether the AEM-side configuration or the Microsoft®-side tenant settings are responsible.

The tool is community software and is not officially supported by Adobe. The note makes it discoverable for documentation readers as an additional self-service option.

## Notes for reviewers

- Change is scoped to the `### Troubleshooting` section; no existing content is modified.
- The tool link points at the public GitHub repository under Apache-2.0.
- Happy to adjust wording — please reach out via Slack at \`wunsch@adobe.com\` if you'd like edits before merge.

> Note on PR identity: this PR is opened from the personal \`rwunsch\` GitHub account because Adobe-managed (\`wunsch_adobe\`) accounts cannot fork external repos. The commit itself is authored by \`wunsch_adobe / wunsch@adobe.com\`.

## Tests

n/a — documentation-only addition.